### PR TITLE
Use up2date configured proxy, if set

### DIFF
--- a/bin/spacewalk-resolver.py
+++ b/bin/spacewalk-resolver.py
@@ -101,6 +101,13 @@ class SpacewalkResolverPlugin(Plugin):
                 self.auth_headers[k] = v
         #self.answer("META", li)
 
+        proxystr = ""
+        if rhnChannel.config.cfg['enableProxy'] == 1:
+            proxy_config = rhnChannel.config.getProxySetting()
+            if proxy_config:
+                (proxy_host, proxy_port) = proxy_config.split(':')
+                proxystr = "&proxy=%s&proxyport=%s" % (proxy_host, proxy_port)
+
         # url is a list, use the one provided by the given server
         if type(self.channel['url']) == type([]):
             self.channel['url'] = self.channel['url'][server]
@@ -109,6 +116,7 @@ class SpacewalkResolverPlugin(Plugin):
             timeoutstr = "&timeout=%d" % timeout
         url = "%s/GET-REQ/%s?head_requests=no%s" % (self.channel['url'],
                                                     self.channel['label'],
+                                                    proxystr,
                                                     timeoutstr)
 
         self.answer("RESOLVEDURL", self.auth_headers, url)

--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -60,6 +60,9 @@ except up2dateErrors.Error as e:
 except:
     sys.exit(1)
 
+enable_proxy = rhnChannel.config.cfg['enableProxy']
+proxy_config = rhnChannel.config.getProxySetting()
+
 service_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 print("# Channels for service %s" % service_name)
 for channel in svrChannels:
@@ -105,3 +108,5 @@ for channel in svrChannels:
         else:
             _sendback("pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1")))
         _sendback("repo_gpgcheck=0")
+    if enable_proxy == 1 and proxy_config:
+        _sendback("proxy=%s" % proxy_config)


### PR DESCRIPTION
When the up2date configuration has a HTTP proxy configured, the
Zypper operations should use and respect that.